### PR TITLE
Allow provider creator to npm-link to local folder for dev npm testing

### DIFF
--- a/networks.js
+++ b/networks.js
@@ -8,7 +8,7 @@ module.exports = {
     networks: {
         testSdk: {
             host: '127.0.0.1',
-            port: 7545,
+            port: 8545,
             network_id: 5777,
             gas: "6721975",
             gasPrice: "10000000"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "bin": {
-    "zapcli": "./src/api/index.js"
+    "zapcli": "./src/api/contracts-bundle.js"
   },
-  "name": "synapse-poc",
+  "name": "zapsdk",
   "version": "0.0.0",
   "private": true,
+  "main":"./src/api/contracts-bundle.js",
   "dependencies": {
     "async": "^2.5.0",
     "aws-lambda-invoke": "^3.0.0",

--- a/src/api/contracts-bundle.js
+++ b/src/api/contracts-bundle.js
@@ -5,12 +5,12 @@ require('babel-polyfill');
 const fs = require('fs');
 
 // Truffle contracts artifacts
-global.ZapArbiterArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/Arbiter.json'));
-global.ZapBondageArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/Bondage.json'));
-global.ZapBondageStorageArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/BondageStorage.json'));
-global.ZapDispatchArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/Dispatch.json'));
-global.ZapRegistryArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/Registry.json'));
-global.ZapTokenArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../artifacts/contracts/ZapToken.json'));
+global.ZapArbiterArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts/Arbiter.json'));
+global.ZapBondageArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts//Bondage.json'));
+global.ZapBondageStorageArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts/BondageStorage.json'));
+global.ZapDispatchArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts/Dispatch.json'));
+global.ZapRegistryArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts/Registry.json'));
+global.ZapTokenArtifact = JSON.parse(fs.readFileSync(__dirname + '/../../ZapContracts/build/contracts/ZapToken.json'));
 
 // Contract wrappers
 global.ZapArbiter = require("./contracts/Arbiter");

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -10,7 +10,7 @@ const path = require('path');
 const { serverOptions } = require('../config/server.js');
 // const {} = require('web3-provider-engine/');
 
-const { networks } = require('../truffle.js');
+const { networks } = require('../networks.js');
 const { promisify } = require('util');
 const asyncMigrate = promisify(migrate.run);
 const {


### PR DESCRIPTION
- package.json to look at the contracts-bundle
- contracts-bundle to look at submodule artifacts
- change truffle.js -> networks.js , in the understanding that sdk doesnt need its own truffle env